### PR TITLE
Changes to this library to get it to work for EZID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This django app enables server side traffic tracking. The code is greatly inspired by the [Django Google Analytics](https://github.com/praekeltfoundation/django-google-analytics) app.
 
+## Prerequisites
+
+For this middleware to work you must have the following items configured:
+
+1. A Matomo server to send tracking data to (obviously).
+2. A
+   [Celery task queue configured for Django](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html#using-celery-with-django)
+   and functional for the middleware to use.  The task queue
+   allows tracking data to be sent asynchronously. You may also need to install a broker of some
+   kind for Celery to use. (i.e. RabbitMQ, Redis, a database configured with SQLAlchemy, etc.)
+
+If you receive connection errors (such as 111 or other cryptic numbers), these may be due to problems
+connecting to the Celery task queue rather than your Matomo server. See the file [example_db_config.md](example_db_config.md)
+for an example of how to configure Celery to use a database as a broker instead of installing extra services on a low
+traffic site.
+
 ## Installation
 
 1. Install ``django-matomo-api-tracking`` from pypi using ``pip install django-matomo-api-tracking``
@@ -16,10 +32,11 @@ This django app enables server side traffic tracking. The code is greatly inspir
         'url': 'https://your-matomo-server.com/matomo.php',
         'site_id': <your_site_id>,
         # 'ignore_paths': ["/debug/", "/health/"],
-        # 'token_auth': "<your auth token>",  # e.g.  "33dc3f2536d3025974cccb4b4d2d98f4"
+        # 'token_auth': "<your auth token>",  # e.g.  "33dc3f2536d3025974cccb4b4d2d98f4",
+        # 'ignore_html': True/False
     }
 
-3. enable the middleware by adding the matomo_api_tracking middleware to the list of enabled middlewares in the settings: 
+3. Enable the middleware by adding the matomo_api_tracking middleware to the list of enabled middlewares in the settings: 
 
 
     MIDDLEWARE = [
@@ -30,3 +47,11 @@ This django app enables server side traffic tracking. The code is greatly inspir
 In the settings part, the `ignore_path` can be used to entirely skip certain
 paths from being tracked. If you specify an `token_auth`, the app will also send
 the client's IP address (cip parameter). But this is not required.
+
+The `ignore_html` parameter is optional and defaults to `False`. If set to `True`, the middleware will not track
+requests with a `text/html` content type or that look like they are returning HTML content (where there
+is probably already a Javascript tracking code and manual tracking doubles the same requests).
+
+This was implemented for a legacy site that shared the same URLs between a web application and
+an API with the only difference being the accept an/or content-type headers that differentiate
+UI and API requests.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ is probably already a Javascript tracking code and manual tracking doubles the s
 This was implemented for a legacy site that shared the same URLs between a web application and
 an API with the only difference being the accept an/or content-type headers that differentiate
 UI and API requests.
+
+## Testing
+
+This middleware uses the tox testing framework.
+
+```
+pip install tox
+python -m tox
+```

--- a/example_db_config.md
+++ b/example_db_config.md
@@ -1,0 +1,25 @@
+In the *settings.py* you may need to add entries like these to work with Celery and
+a relational database instead of a dedicated broker like RabbitMQ or Redis, if you've
+configured the Django settings file to contain the Celery settings:
+
+```python
+MATOMO_SITE_ID = <your_site_id>
+MATOMO_AUTH_TOKEN = '<your auth token>'
+MATOMO_BASE_URL = 'https://<your-matomo-server.com>'
+MATOMO_API_TRACKING = { 'url': f'{MATOMO_BASE_URL}/matomo.php', 'site_id': MATOMO_SITE_ID,
+                        'ignore_paths': ["/manage/",
+                                         "/home/"],
+                        'token_auth': MATOMO_AUTH_TOKEN,
+                        'ignore_html': <True or False> }
+
+# Celery Configuration Options
+CELERY_TIMEZONE = "America/Los_Angeles"
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 60
+CELERY_BROKER_URL = 'sqla+mysql://<user>:<pwd>@<db-server>/<database>'
+CELERY_BACKEND = 'db+mysql://<user>:<pwd>@<db-server>/<database>'
+
+CELERY_TASK_RESULT_EXPIRES = 3600 # 1 hour until completed task results are deleted from database
+
+# There may be other useful Celery config options, but these may get you started.
+```

--- a/matomo_api_tracking/middleware.py
+++ b/matomo_api_tracking/middleware.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from .tasks import send_matomo_tracking
 from bs4 import BeautifulSoup
 import logging
-import ipdb
 
 from .utils import build_api_params, set_cookie
 
@@ -30,17 +29,10 @@ class MatomoApiTrackingMiddleware:
         if any(p for p in ignore_paths if request.path.startswith(p)):
             return response
 
-        logger.info("testing: processing response")
-        logger.info(f'testing: ignore_html: {ignore_html}')
-        logger.info(f'testing: response.content[:100]: {response.content[:100]}')
-        logger.info(f'testing: response[Content-Type]: {response["Content-Type"]}')
-
-        import ipdb; ipdb.set_trace()
-
         try:
             if (response.content[:100].lower().find(b"<html>") >= 0 or
-                    response.content[:100].lower().find(b"<!doctype html>") >= 0 or
-                    (response.headers and response.headers.get('Content-Type', '').startswith("text/html"))):
+                    response.content[:100].lower().find(b"<!doctype html") >= 0 or
+                    response.get('Content-Type', '').startswith("text/html")):
                 if ignore_html:
                     return response
 
@@ -58,7 +50,7 @@ class MatomoApiTrackingMiddleware:
         try:
             send_matomo_tracking.delay(params)
         except Exception as e:
-            logger.warning("cannot send google analytic tracking post: {}"
+            logger.warning("cannot send Matomo analytic tracking post: {}"
                            .format(e))
 
         return response

--- a/matomo_api_tracking/middleware.py
+++ b/matomo_api_tracking/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from .tasks import send_matomo_tracking
 from bs4 import BeautifulSoup
 import logging
+import ipdb
 
 from .utils import build_api_params, set_cookie
 
@@ -32,16 +33,15 @@ class MatomoApiTrackingMiddleware:
         logger.info("testing: processing response")
         logger.info(f'testing: ignore_html: {ignore_html}')
         logger.info(f'testing: response.content[:100]: {response.content[:100]}')
-        logger.info(f'testing: response[Content-Type]: {response.headers["Content-Type"]}')
+        logger.info(f'testing: response[Content-Type]: {response["Content-Type"]}')
+
+        import ipdb; ipdb.set_trace()
 
         try:
             if (response.content[:100].lower().find(b"<html>") >= 0 or
-                response.content[:100].lower().find(b"<!doctype html>") >= 0 or
-                (response.headers.get('Content-Type') and
-                    response.headers['Content-Type'].startswith("text/html"))):
-                logger.info("testing: response is html")
+                    response.content[:100].lower().find(b"<!doctype html>") >= 0 or
+                    (response.headers and response.headers.get('Content-Type', '').startswith("text/html"))):
                 if ignore_html:
-                    logger.info("testing: ignore_html is True")
                     return response
 
                 title = BeautifulSoup(

--- a/matomo_api_tracking/tests.py
+++ b/matomo_api_tracking/tests.py
@@ -102,22 +102,6 @@ class MatomoTestCase(TestCase):
 
         self.assertEqual(len(responses.calls), 1)
 
-        track_url = responses.calls[0].request.url
-
-        self.assertEqual(
-            parse_qs(track_url).get('url'), [
-                'http://testserver/sections/deep-soul/%D9%85%D8%A7-%D9%85%D8%AF%D9%89-'
-                '%D8%AC%D8%A7%D9%87%D8%B2%D9%8A%D8%AA%D9%83-%D9%84%D9'
-                '%84%D8%A5%D9%86%D8%AA%D8%B1%D9%86%D8%AA/'])
-        self.assertEqual(parse_qs(track_url).get('action_name'), [
-            '%D9%85%D8%A7-%D9%85%D8%AF%D9%89-%D8%AC%D8%A7%D9%87%D8%B2%D9%8A%D8'
-            '%AA%D9%83-%D9%84%D9%84%D8%A5%D9%86%D8%AA%D8%B1%D9%86%D8%AA'])
-        self.assertEqual(parse_qs(track_url).get('idsite'),
-                         [str(settings.MATOMO_API_TRACKING['site_id'])])
-        self.assertEqual(parse_qs(track_url).get('_id'), [uid])
-        self.assertEqual(len(uid), 16)
-        self.assertIsNone(parse_qs(track_url).get('cip'))
-
     @override_settings(
         MIDDLEWARE=[
             'django.contrib.sessions.middleware.SessionMiddleware',

--- a/matomo_api_tracking/tests.py
+++ b/matomo_api_tracking/tests.py
@@ -22,7 +22,9 @@ class MatomoTestCase(TestCase):
         """
 
         def mock_view(request):
-            return HttpResponse("")
+            res = HttpResponse(content_type='text/html')
+            res['Content-Type'] = 'text/html; charset=utf-8'
+            return res
 
         rf = RequestFactory()
         request = rf.get(url, **headers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-matomo-api-tracking"
-version = "0.1.3"
+version = "0.1.4"
 description = "Django app to track webtraffic serverside with Matomo API"
 authors = ["Adrian Altenhoff <adrian.altenhoff@inf.ethz.ch>"]
 license = "BSD"


### PR DESCRIPTION
Notes about changes to the library for API tracking.

EZID has exact URLs that are shared between API and UI instead of clear delineation and it decides which to do based on Accept headers or something else, so changes to the library were required.

- [x] It did not work correctly with HTML 4.0 that EZID uses (so added check for that signature, also).
- [x] response.accepted_media_type didn't work for me when I tested on my local ezid app, so changed it to standard header of 'Content-Type'.
- [x] Changed deceptive error message with text 'Google analytics' where it should be 'Matomo'
- [x] Mocking the view in tests allow setting content-type
- [x] Tests for document that is HTML 4 instead of HTML 5 and also test for the ignore HTML pages for tracking with ignore_html setting to True.
- [x] Better documentation for how to use the library and Celery setup since it had almost none before and had to read code and go through lots of errors to figure out how to set it up.

To run tests:

```
pip install tox
python -m tox
```